### PR TITLE
Typo on Registrant endpoint.

### DIFF
--- a/src/Registrant.php
+++ b/src/Registrant.php
@@ -92,7 +92,7 @@ class Registrant extends Model
     public function get()
     {
         if (in_array('get', $this->methods)) {
-            $this->response = $this->client->get($this->type."/{$this->relationshipID}/registarants".$this->getQueryString());
+            $this->response = $this->client->get($this->type."/{$this->relationshipID}/registrants".$this->getQueryString());
             if ($this->response->getStatusCode() == '200') {
                 return $this->collect($this->response->getBody());
             } else {
@@ -104,7 +104,7 @@ class Registrant extends Model
     public function all()
     {
         if ($this->relationshipID != '') {
-            return $this->collect($this->get($this->type."/{$this->relationshipID}/registarants"));
+            return $this->collect($this->get($this->type."/{$this->relationshipID}/registrants"));
         } else {
             throw new Exception('No Relationship set');
         }


### PR DESCRIPTION
Fix for 404 when doing ->get() or ->all() on Registrant model. URL should end on 'registrants' not 'registarants'. Check https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingregistrants for further information.