### PR TITLE
Adds recursive paginated API call on all method in Model to capture entire dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.DS_Store

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -151,14 +151,14 @@ abstract class Model
                 if (is_array($value) && in_array($class->getKey(), $value)) {
                     $class->fill($value);
                     $this->attributes[$key] = $class;
-                } else if(is_array($value)){
+                } elseif (is_array($value)) {
                     foreach ($value as $index => $class) {
                         $new_class = new $this->relationships[$key];
                         $new_class->fill($class);
                         $this->attributes[$key][$index] = $new_class;
                     }
                 } else {
-                    $this->attributes[$key] = $value;    
+                    $this->attributes[$key] = $value;
                 }
             } else {
                 $this->attributes[$key] = $value;

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -338,7 +338,7 @@ abstract class Model
     public function all()
     {
         if (in_array('get', $this->methods)) {
-            $this->response = $this->client->get($this->getEndpoint());
+            $this->response = $this->client->get($this->getEndpoint().$this->getQueryString());
             if ($this->response->getStatusCode() == '200') {
                 return $this->collect($this->response->getBody());
             } else {

--- a/src/User.php
+++ b/src/User.php
@@ -13,7 +13,7 @@ class User extends Model
 
     protected $methods = ['get', 'post', 'patch', 'put', 'delete'];
 
-    protected $queryAttributes = ['status', 'page_size', 'page_number', 'role_id'];
+    protected $queryAttributes = ['status', 'limit', 'role_id'];
 
     protected $attributes = [
         'first_name' => '', //string

--- a/src/User.php
+++ b/src/User.php
@@ -13,6 +13,8 @@ class User extends Model
 
     protected $methods = ['get', 'post', 'patch', 'put', 'delete'];
 
+    protected $queryAttributes = ['status', 'page_size', 'page_number', 'role_id'];
+
     protected $attributes = [
         'first_name' => '', //string
         'last_name' => '', //string


### PR DESCRIPTION
# Summary
When attempting to return all users using the `all()` method, it instead returned a limited number of users due to the default `page_size` query param being set to 30. This pull requests adds queryAttributes to the User model and recursively calls the `all()` method until users on all available pages have been queried and then collects that dataset for the response.

## Examples
#### Get all users
```
$zoom = new \MacsiDigital\Zoom\Zoom;
$users = $zoom->user->all();
```
#### Get all active users
```
$zoom = new \MacsiDigital\Zoom\Zoom;
$users = $zoom->user->where('status', 'active')->all();
```
#### Limit the number of users
This particular example just bypasses the pagination and returns a defined number of users instead.
 _Max: 300_
```
$zoom = new \MacsiDigital\Zoom\Zoom;
$users = $zoom->user->where('limit', 5)->all();
```

## Other information
- Added .DS_Store to the .gitignore
- Corrected discouraged use of `else if` in Model

### Helpful Links
- [Zoom API - Users](https://marketplace.zoom.us/docs/api-reference/zoom-api/users/users)