### PR TITLE
Correct the status code checks for POST and PATCH endpoints

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -73,7 +73,7 @@ class User extends Model
         if ($this->hasID()) {
             if (in_array('put', $this->methods)) {
                 $this->response = $this->client->patch("{$this->getEndpoint()}/{$this->getID()}", $this->updateAttributes());
-                if ($this->response->getStatusCode() == '200') {
+                if ($this->response->getStatusCode() == '200' || $this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
                     throw new Exception($this->response->getStatusCode().' status code');
@@ -83,7 +83,7 @@ class User extends Model
             if (in_array('post', $this->methods)) {
                 $attributes = ['action' => 'create', 'user_info' => $this->createAttributes()];
                 $this->response = $this->client->post($this->getEndpoint(), $attributes);
-                if ($this->response->getStatusCode() == '200') {
+                if ($this->response->getStatusCode() == '201') {
                     $this->fill($this->response->getBody());
 
                     return $this;


### PR DESCRIPTION
Zoom User API returns:

* 201 for POST (https://marketplace.zoom.us/docs/api-reference/zoom-api/users/usercreate)
* 204 for PATCH (https://marketplace.zoom.us/docs/api-reference/zoom-api/users/userupdate)

I tested and verified this behavior as well. I'm actually pretty certain it doesn't need the 200 but I left it for now. 