### PR TITLE
Feature/http exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,12 @@
         }
     ],
     "require": {
-        "php": "^7.2", 
+        "php": "^7.2",
         "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
         "firebase/php-jwt": "^5.0",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0",
+        "ext-json": "*",
+        "ext-http": "*"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,7 @@
         "php": "^7.2",
         "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
         "firebase/php-jwt": "^5.0",
-        "illuminate/support": "^6.0|^7.0",
-        "ext-json": "*",
-        "ext-http": "*"
+        "illuminate/support": "^6.0|^7.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",

--- a/src/Exceptions/ZoomHttpException.php
+++ b/src/Exceptions/ZoomHttpException.php
@@ -4,4 +4,9 @@ namespace MacsiDigital\Zoom\Exceptions;
 
 class ZoomHttpException extends \Exception
 {
+    public function __construct($code = 0, $errorResponse = [], \Throwable $previous = null)
+    {
+        $message = $errorResponse['message'];
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Exceptions/ZoomHttpException.php
+++ b/src/Exceptions/ZoomHttpException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace MacsiDigital\Zoom\Exceptions;
+
+class ZoomHttpException extends \Exception
+{
+}

--- a/src/Meeting.php
+++ b/src/Meeting.php
@@ -3,6 +3,7 @@
 namespace MacsiDigital\Zoom;
 
 use Exception;
+use MacsiDigital\Zoom\Exceptions\ZoomHttpException;
 use MacsiDigital\Zoom\Support\Model;
 
 class Meeting extends Model
@@ -119,7 +120,7 @@ class Meeting extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -135,7 +136,7 @@ class Meeting extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -151,7 +152,7 @@ class Meeting extends Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -162,7 +163,7 @@ class Meeting extends Model
 
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -183,7 +184,7 @@ class Meeting extends Model
         if ($this->response->getStatusCode() == '200') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -193,7 +194,7 @@ class Meeting extends Model
         if ($this->response->getStatusCode() == '200') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -203,7 +204,7 @@ class Meeting extends Model
         if ($this->response->getStatusCode() == '200') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 }

--- a/src/Meeting.php
+++ b/src/Meeting.php
@@ -119,11 +119,11 @@ class Meeting extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
-            throw new Exception('No User to retreive Meetings');
+            throw new Exception('No User to retrieve Meetings');
         }
     }
 
@@ -135,7 +135,7 @@ class Meeting extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -151,7 +151,7 @@ class Meeting extends Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -162,7 +162,7 @@ class Meeting extends Model
 
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -183,7 +183,7 @@ class Meeting extends Model
         if ($this->response->getStatusCode() == '200') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -193,7 +193,7 @@ class Meeting extends Model
         if ($this->response->getStatusCode() == '200') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -203,7 +203,7 @@ class Meeting extends Model
         if ($this->response->getStatusCode() == '200') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 }

--- a/src/Registrant.php
+++ b/src/Registrant.php
@@ -96,7 +96,7 @@ class Registrant extends Model
             if ($this->response->getStatusCode() == '200') {
                 return $this->collect($this->response->getBody());
             } else {
-                throw new Exception($this->response->getStatusCode().' status code');
+                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }
@@ -118,7 +118,7 @@ class Registrant extends Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -129,7 +129,7 @@ class Registrant extends Model
 
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -146,7 +146,7 @@ class Registrant extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -156,7 +156,7 @@ class Registrant extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -166,7 +166,7 @@ class Registrant extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 }

--- a/src/Registrant.php
+++ b/src/Registrant.php
@@ -3,6 +3,7 @@
 namespace MacsiDigital\Zoom;
 
 use Exception;
+use MacsiDigital\Zoom\Exceptions\ZoomHttpException;
 use MacsiDigital\Zoom\Support\Model;
 
 class Registrant extends Model
@@ -96,7 +97,7 @@ class Registrant extends Model
             if ($this->response->getStatusCode() == '200') {
                 return $this->collect($this->response->getBody());
             } else {
-                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }
@@ -118,7 +119,7 @@ class Registrant extends Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -129,7 +130,7 @@ class Registrant extends Model
 
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -146,7 +147,7 @@ class Registrant extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -156,7 +157,7 @@ class Registrant extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -166,7 +167,7 @@ class Registrant extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 }

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -16,6 +16,7 @@ abstract class Model
     protected $queries = [];
     protected $methods = [];
 
+    /** @var Response */
     public $response;
     public $mergedResponse = [];
 
@@ -271,7 +272,7 @@ abstract class Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new Exception('Status Code '.$this->response->getStatusCode());
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -282,7 +283,7 @@ abstract class Model
 
                     return $this;
                 } else {
-                    throw new Exception('Status Code '.$this->response->getStatusCode());
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -331,7 +332,7 @@ abstract class Model
             if ($this->response->getStatusCode() == '200') {
                 return $this->collect($this->response->getBody());
             } else {
-                throw new Exception('Status Code '.$this->response->getStatusCode());
+                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }
@@ -355,7 +356,7 @@ abstract class Model
 
                 return $this->collect($res);
             } else {
-                throw new Exception('Status Code '.$this->response->getStatusCode());
+                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }
@@ -382,7 +383,7 @@ abstract class Model
             if ($this->response->getStatusCode() == '204') {
                 return $this->response->getStatusCode();
             } else {
-                throw new Exception('Status Code '.$this->response->getStatusCode());
+                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -272,7 +272,7 @@ abstract class Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -283,7 +283,7 @@ abstract class Model
 
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -332,7 +332,7 @@ abstract class Model
             if ($this->response->getStatusCode() == '200') {
                 return $this->collect($this->response->getBody());
             } else {
-                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }
@@ -356,7 +356,7 @@ abstract class Model
 
                 return $this->collect($res);
             } else {
-                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }
@@ -383,7 +383,7 @@ abstract class Model
             if ($this->response->getStatusCode() == '204') {
                 return $this->response->getStatusCode();
             } else {
-                throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
             }
         }
     }

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -5,6 +5,7 @@ namespace MacsiDigital\Zoom\Support;
 use Exception;
 use Illuminate\Support\Collection;
 use MacsiDigital\Zoom\Facades\Zoom;
+use MacsiDigital\Zoom\Exceptions\ZoomHttpException;
 
 abstract class Model
 {

--- a/src/User.php
+++ b/src/User.php
@@ -3,6 +3,7 @@
 namespace MacsiDigital\Zoom;
 
 use MacsiDigital\Zoom\Support\Model;
+use MacsiDigital\Zoom\Exceptions\ZoomHttpException;
 
 class User extends Model
 {
@@ -75,7 +76,7 @@ class User extends Model
                 if ($this->response->getStatusCode() == '200' || $this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -87,7 +88,7 @@ class User extends Model
 
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }

--- a/src/User.php
+++ b/src/User.php
@@ -73,7 +73,7 @@ class User extends Model
         if ($this->hasID()) {
             if (in_array('put', $this->methods)) {
                 $this->response = $this->client->patch("{$this->getEndpoint()}/{$this->getID()}", $this->updateAttributes());
-                if ($this->response->getStatusCode() == '200') {
+                if ($this->response->getStatusCode() == '200' || $this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
                     throw new Exception($this->response->getStatusCode().' status code');
@@ -83,7 +83,7 @@ class User extends Model
             if (in_array('post', $this->methods)) {
                 $attributes = ['action' => 'create', 'user_info' => $this->createAttributes()];
                 $this->response = $this->client->post($this->getEndpoint(), $attributes);
-                if ($this->response->getStatusCode() == '200') {
+                if ($this->response->getStatusCode() == '201') {
                     $this->fill($this->response->getBody());
 
                     return $this;

--- a/src/User.php
+++ b/src/User.php
@@ -2,7 +2,6 @@
 
 namespace MacsiDigital\Zoom;
 
-use Exception;
 use MacsiDigital\Zoom\Support\Model;
 
 class User extends Model
@@ -76,7 +75,7 @@ class User extends Model
                 if ($this->response->getStatusCode() == '200' || $this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -88,7 +87,7 @@ class User extends Model
 
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }

--- a/src/Webinar.php
+++ b/src/Webinar.php
@@ -4,6 +4,7 @@ namespace MacsiDigital\Zoom;
 
 use Exception;
 use MacsiDigital\Zoom\Support\Model;
+use MacsiDigital\Zoom\Exceptions\ZoomHttpException;
 
 class Webinar extends Model
 {
@@ -118,7 +119,7 @@ class Webinar extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -134,7 +135,7 @@ class Webinar extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -150,7 +151,7 @@ class Webinar extends Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -161,7 +162,7 @@ class Webinar extends Model
 
                     return $this;
                 } else {
-                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+                    throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -190,7 +191,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -200,7 +201,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -210,7 +211,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -220,7 +221,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -230,7 +231,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
+            throw new ZoomHttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 }

--- a/src/Webinar.php
+++ b/src/Webinar.php
@@ -118,7 +118,7 @@ class Webinar extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -134,7 +134,7 @@ class Webinar extends Model
                 if ($this->response->getStatusCode() == '200') {
                     return $this->collect($this->response->getBody());
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -150,7 +150,7 @@ class Webinar extends Model
                 if ($this->response->getStatusCode() == '204') {
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         } else {
@@ -161,7 +161,7 @@ class Webinar extends Model
 
                     return $this;
                 } else {
-                    throw new Exception($this->response->getStatusCode().' status code');
+                    throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
                 }
             }
         }
@@ -190,7 +190,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -200,7 +200,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -210,7 +210,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -220,7 +220,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 
@@ -230,7 +230,7 @@ class Webinar extends Model
         if ($this->response->getStatusCode() == '204') {
             return $this->response->getBody();
         } else {
-            throw new Exception($this->response->getStatusCode().' status code');
+            throw new \HttpException($this->response->getStatusCode(), $this->response->getBody());
         }
     }
 }


### PR DESCRIPTION
Zoom sends a useful error message in their http responses but the way the exceptions were written it was hard to get that information. 

This PR converts the exceptions to HttpExceptions and then sets the code to the http status code, and the message to the message body returned by zoom api.