### PR TITLE
Delete Meeting Recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ At present we cover the following modules
 - Past Meetings
 - Webinars
 - Past Webinars
-- Recordings (get only)
+- Recordings
 
 Doesn't look like a lot but Meetings and Webinars are the 2 big modules and includes, polls, registration questions, registrants, panelists and various other relationships.
 
@@ -638,7 +638,7 @@ This is the main access for most models in Zoom.
     $meeting->liveStream // hasOne relationship
     $meeting->registrationQuestions // hasMany relationship
     $meeting->trackingFields // hasMany relationship
-    $meeting->recordings // hasOne relationship
+    $meeting->recording // hasOne relationship
 
     // Once we have the meeting we can update registrants
      
@@ -663,10 +663,13 @@ This is the main access for most models in Zoom.
     // Special functions
      
     // End Meeting
-    $meeting->endMeeting()
+    $meeting->endMeeting();
 
     // delete
     $meeting->delete($scheduleForReminder); // Delete (destroy) meeting. ScheduleForReminder true by default
+
+    //Delete Meeting Recording
+    $meeting->recording->delete();  //Delete (destroy) the recording of the meeting.
 ```
 
 #### Webinars

--- a/src/MeetingRecording.php
+++ b/src/MeetingRecording.php
@@ -8,9 +8,10 @@ class MeetingRecording extends Model
 {
     protected $customEndPoints = [
         'get' => 'meetings/{meeting:id}/recordings',
+        'delete' => 'meetings/{meeting:id}/recordings'
     ];
 
-    protected $allowedMethods = ['get'];
+    protected $allowedMethods = ['get', 'delete'];
 
     public function recordingFiles()
     {
@@ -20,5 +21,10 @@ class MeetingRecording extends Model
     public function recordingPasswordRequirement()
     {
         return $this->hasOne(RecordingPasswordRequirement::class);
+    }
+
+    public function delete()
+    {
+        return $this->newQuery()->delete();
     }
 }


### PR DESCRIPTION
### Changes
 - Added feature to delete recording of a meeting. 
 - Modified Readme.md.
 
### Reference
[Zoom API endpoint](https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingdeleteone) for deleting a recording of a meeting.
