### PR TITLE
Configurable Entry parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ There are 2 main ways to work with models, to call them directly from the access
     $user = new \MacsiDigital\Zoom\User($zoom);
 ```
 
+### Custom settings
+If you would like to use different configuration values than those in your zoom.php config file, you can feed those as parameters to \MacsiDigital\Zoom\Support\Entry as shown below.
+``` php
+    $zoom = new \MacsiDigital\Zoom\Support\Entry($apiKey, $apiSecret, $tokenLife, $maxQueries, $baseUrl);
+```
+
 ### Working with models
 
 As noted we are aiming for functionality similar to Laravel, so most things that you can do in Laravel you can do here, with exception to any database specific functionality, as we are not using databases.

--- a/src/Support/Entry.php
+++ b/src/Support/Entry.php
@@ -44,12 +44,12 @@ class Entry extends ApiEntry
      * @param $maxQueries
      * @param $baseUrl
      */
-    public function __construct($apiKey, $apiSecret, $tokenLife, $maxQueries, $baseUrl)
+    public function __construct($apiKey = null, $apiSecret = null, $tokenLife = null, $maxQueries = null, $baseUrl = null)
     {
         $this->apiKey = $apiKey ? $apiKey : config('zoom.api_key');
         $this->apiSecret = $apiSecret ? $apiSecret : config('zoom.api_secret');
         $this->tokenLife = $tokenLife ? $tokenLife : config('zoom.token_life');
-        $this->maxQueries = $maxQueries ? $maxQueries : config('zoom.max_api_calls_per_request') ? config('zoom.max_api_calls_per_request') : $this->maxQueries;
+        $this->maxQueries = $maxQueries ? $maxQueries : (config('zoom.max_api_calls_per_request') ? config('zoom.max_api_calls_per_request') : $this->maxQueries);
         $this->baseUrl = $baseUrl ? $baseUrl : config('zoom.base_url');
     }
 

--- a/src/Support/Entry.php
+++ b/src/Support/Entry.php
@@ -14,6 +14,14 @@ class Entry extends ApiEntry
 
     protected $maxQueries = '5';
 
+    protected $apiKey = null;
+
+    protected $apiSecret = null;
+
+    protected $tokenLife = null;
+
+    protected $baseUrl = null;
+
     // Amount of pagination results per page by default, leave blank if should not paginate
     // Without pagination rate limits could be hit
     protected $defaultPaginationRecords = '30';
@@ -28,11 +36,21 @@ class Entry extends ApiEntry
 
     protected $allowedOperands = ['='];
 
-    public function __construct()
+    /**
+     * Entry constructor.
+     * @param $apiKey
+     * @param $apiSecret
+     * @param $tokenLife
+     * @param $maxQueries
+     * @param $baseUrl
+     */
+    public function __construct($apiKey, $apiSecret, $tokenLife, $maxQueries, $baseUrl)
     {
-        if (config('zoom.max_api_calls_per_request') != null) {
-            $this->maxQueries = config('zoom.max_api_calls_per_request');
-        }
+        $this->apiKey = $apiKey ? $apiKey : config('zoom.api_key');
+        $this->apiSecret = $apiSecret ? $apiSecret : config('zoom.api_secret');
+        $this->tokenLife = $tokenLife ? $tokenLife : config('zoom.token_life');
+        $this->maxQueries = $maxQueries ? $maxQueries : config('zoom.max_api_calls_per_request') ? config('zoom.max_api_calls_per_request') : $this->maxQueries;
+        $this->baseUrl = $baseUrl ? $baseUrl : config('zoom.base_url');
     }
 
     public function newRequest()
@@ -45,9 +63,9 @@ class Entry extends ApiEntry
 
     public function jwtRequest()
     {
-        $jwtToken = JWT::generateToken(['iss' => config('zoom.api_key'), 'exp' => time() + config('zoom.token_life')], config('zoom.api_secret'));
-        
-        return Client::baseUrl(config('zoom.base_url'))->withToken($jwtToken);
+        $jwtToken = JWT::generateToken(['iss' => $this->apiKey, 'exp' => time() + $this->tokenLife], $this->apiSecret);
+
+        return Client::baseUrl($this->baseUrl)->withToken($jwtToken);
     }
 
     public function oauth2Request()


### PR DESCRIPTION
I made some changes to the Entry class, which will allow you to feed configuration parameters to the constructor. This allows people to use multiple Zoom API keys if necessary, or change the baseurl on demand.

I also added some documentation in the readme file.

Hope this is useful :)