### PR TITLE
Webinar delete failed issue fix.

### DIFF
--- a/src/Webinar.php
+++ b/src/Webinar.php
@@ -74,6 +74,11 @@ class Webinar extends Model
     {
         return $this->hasMany(Poll::class);
     }
+    
+    public function delete($scheduleForReminder = true)
+    {
+        return $this->newQuery()->addQuery('schedule_for_reminder', $scheduleForReminder)->delete();
+    }
 
     public function endWebinar()
     {


### PR DESCRIPTION
I got this error when implementing webinars through my laravel application.

Too few arguments to function MacsiDigital\API\Support\ApiResource::beforeDeleting(), 0 passed in C:\xampp\htdocs\website\vendor\macsidigital\laravel-api-client\src\Traits\InteractsWithAPI.php on line 528 and exactly 1 expected

I fixed the issue by adding delete function (Taken from Meeting model)

Laravel Version : 7