### PR TITLE
Updated OAuth spelling and README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ This will create a zoom.php config file within your config directory:-
 
 ```php
 return [
-    'apiKey' => env('ZOOM_CLIENT_KEY'),
-    'apiSecret' => env('ZOOM_CLIENT_SECRET'),
-    'baseUrl' => 'https://api.zoom.us/v2/',
+    'account_id' => env('ZOOM_ACCOUNT_ID'),
+    'client_id' => env('ZOOM_CLIENT_ID'),
+    'client_secret' => env('ZOOM_CLIENT_SECRET'),
+    'api_key' => env('ZOOM_CLIENT_KEY'),
+    'api_secret' => env('ZOOM_CLIENT_SECRET'),
+    'base_url' => 'https://api.zoom.us/v2/',
     'token_life' => 60 * 60 * 24 * 7, // In seconds, default 1 week
-    'authentication_method' => 'jwt', // Only jwt compatible at present
+    'authentication_method' => 'OAuth', // Only OAuth compatible at present
     'max_api_calls_per_request' => '5' // how many times can we hit the api to return results for an all() request
 ];
 ```

--- a/config/config.php
+++ b/config/config.php
@@ -6,6 +6,6 @@ return [
     'client_secret' => env('ZOOM_CLIENT_SECRET'),
     'cache_token' => env('ZOOM_CACHE_TOKEN', true),
     'base_url' => 'https://api.zoom.us/v2/',
-    'authentication_method' => 'Oauth', // Only Oauth compatible at present
+    'authentication_method' => 'OAuth', // Only Oauth compatible at present
     'max_api_calls_per_request' => '5' // how many times can we hit the api to return results for an all() request
 ];

--- a/src/Support/Entry.php
+++ b/src/Support/Entry.php
@@ -56,7 +56,7 @@ class Entry extends ApiEntry
 
     public function newRequest()
     {
-        if (strtolower(config('zoom.authentication_method')) == 'oauth') {
+        if (strtolower(config('zoom.authentication_method')) === 'OAuth') {
             return $this->oauthRequest();
         }
 


### PR DESCRIPTION
قمI updated the spelling of the word OAuth because there was a difference in the word written in the config file and the entity file, and I updated the connection method from JWT to OAuth in the README file.